### PR TITLE
Add Dockerfile and Maketargets to simplify development and building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:24.04
+
+WORKDIR /opt
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get -y update && \
+    apt-get -y install python3 python3-pip git
+
+WORKDIR /opt/stocknear-backend
+
+# add local repo stuff so we can test any local modifications
+COPY ./fastify /opt/stocknear-backend/fastify
+COPY ./app /opt/stocknear-backend/app
+COPY ./requirements.txt /opt/stocknear-backend/requirements.txt
+
+# looks like it doesnt let us install things if not in a python virtual environment...
+# which is a good thing, since it can break things. but we are in a container so we dont care
+# add the --break-system-packages flag to ignore the warning
+RUN python3 -m pip install -r requirements.txt --break-system-packages
+
+ENTRYPOINT ["python3", "app/main.py"]

--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,13 @@ docker-bash:
 .PHONY: docker-run
 docker-run:
 	@docker run stocknear:latest
+
+# bring up backend and external rependencies (e.g: redis)
+.PHONY: compose
+compose:
+	@docker-compose -f docker-compose/docker-compose.yaml up
+
+# stop containers
+.PHONY: compose-down
+compose-down:
+	@docker-compose -f docker-compose/docker-compose.yaml down

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+# packages this repo on a container
+.PHONY: build-docker
+build-docker:
+	@docker build . -t stocknear:latest -f Dockerfile
+
+# so you can access the bash on a container, for running manually or debugging
+.PHONY: docker-bash
+docker-bash:
+	@docker run --rm -it --entrypoint bash  stocknear:latest
+
+# run it
+.PHONY: docker-run
+docker-run:
+	@docker run stocknear:latest

--- a/README.md
+++ b/README.md
@@ -40,3 +40,18 @@ If you love the idea of stocknear and want to support our mission you can help u
 
 - Become a [Pro Member](https://stocknear.com/pricing) of stocknear to get unlimited feature access to enjoy the platform to the fullest.
 - You can sponsor us via [Github](https://github.com/sponsors/stocknear) to help us pay the servers & data providers to keep everything running!
+
+# Building
+
+You can build a container with the code in this repo by running
+`make docker-build`
+
+It will take the local version of the code (with your changes in, if any) and use it.
+To start the container, run `make docker-run`
+
+In case you built the container and wants to access its shell for debugging, you can do so with `make docker-bash`
+
+# Issues
+
+- Code currently relies on a bunch of environment variables, which need to be mapped somewhere (and provide descriptive errors if they are missing)
+- It is assumed in the code that the DB is local. That doesnt scale for any serious application, so probably could use some refactoring it to allow remote data storage

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ If you love the idea of stocknear and want to support our mission you can help u
 
 # Building
 
+Requirements: docker
+
 You can build a container with the code in this repo by running
 `make docker-build`
 
@@ -50,6 +52,49 @@ It will take the local version of the code (with your changes in, if any) and us
 To start the container, run `make docker-run`
 
 In case you built the container and wants to access its shell for debugging, you can do so with `make docker-bash`
+
+# Running locally
+
+Requirements: docker-compose
+
+Using docker-compose, you can bring up the containers needed to run the backend (backend app + redis for caching). 
+
+```
+stocknear-backend/ (main) $ make compose                                                                                                                                                [5:48:44]
+Creating network "docker-compose_backend" with the default driver
+Creating network "docker-compose_redis" with the default driver
+Creating docker-compose_redis_1   ... done
+Creating docker-compose_backend_1 ... done
+Attaching to docker-compose_redis_1, docker-compose_backend_1
+redis_1    | 1:C 27 Jan 2025 05:47:23.126 # WARNING Memory overcommit must be enabled! Without it, a background save or replication may fail under low memory condition. Being disabled, it can also cause failures without low memory condition, see https://github.com/jemalloc/jemalloc/issues/1328. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
+redis_1    | 1:C 27 Jan 2025 05:47:23.126 * oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
+redis_1    | 1:C 27 Jan 2025 05:47:23.126 * Redis version=7.4.2, bits=64, commit=00000000, modified=0, pid=1, just started
+redis_1    | 1:C 27 Jan 2025 05:47:23.126 # Warning: no config file specified, using the default config. In order to specify a config file use redis-server /path/to/redis.conf
+redis_1    | 1:M 27 Jan 2025 05:47:23.127 * monotonic clock: POSIX clock_gettime
+redis_1    | 1:M 27 Jan 2025 05:47:23.127 * Running mode=standalone, port=6379.
+redis_1    | 1:M 27 Jan 2025 05:47:23.128 * Server initialized
+redis_1    | 1:M 27 Jan 2025 05:47:23.128 * Ready to accept connections tcp
+backend_1  | Traceback (most recent call last):
+backend_1  |   File "/opt/stocknear-backend/app/main.py", line 116, in <module>
+backend_1  |     cursor.execute("SELECT DISTINCT symbol FROM stocks")
+backend_1  | sqlite3.OperationalError: no such table: stocks
+docker-compose_backend_1 exited with code 1
+^CGracefully stopping... (press Ctrl+C again to force)
+Stopping docker-compose_redis_1   ... done
+```
+
+TODO: Note that if the required databases (sqlite3) are not present, the backend container will fail. We dont have the db and table creation automated just yet, so to make it work you would need to create that yourself. There are some scripts that do it among all the crons inside `./app/`, which can be helpful.
+
+Stop the containers:
+
+```
+make compose-down                                                                                                                                           [5:48:56]
+Removing docker-compose_redis_1   ... done
+Removing docker-compose_backend_1 ... done
+Removing network docker-compose_backend
+Removing network docker-compose_redis
+```
+
 
 # Issues
 

--- a/app/main.py
+++ b/app/main.py
@@ -105,7 +105,7 @@ def db_connection(db_name):
     conn.close()
 
 ################# Redis #################
-redis_client = redis.Redis(host='localhost', port=6380, db=0)
+redis_client = redis.Redis(host='redis', port=6379, db=0)
 redis_client.flushdb() # TECH DEBT
 caching_time = 3600*12 #Cache data for 12 hours
 

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -1,0 +1,19 @@
+services:
+  backend:
+    image: stocknear:latest
+    build: ../
+    ports:
+      - "443:8043"
+    networks:
+      - backend
+      - redis
+  redis:
+    image: redis:7.4-bookworm
+    ports:
+      - "6379:6379"
+    networks:
+      - redis
+networks:
+  # The presence of these objects is sufficient to define them
+  backend: {}
+  redis: {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,5 @@ slowapi
 praw
 fuzzywuzzy
 python-Levenshtein
+orjson
+aiofiles


### PR DESCRIPTION
Create a dockerfile to make the code easier to run (that is, no need to install anything in your machine to get it running)
Added make targers to build, run and get shell on the container
Readme updates with the makefile targets. also noted a couple of things i consider an issue