### PR TITLE
Add external backend-network to support frontend container

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You can build a container with the code in this repo by running
 `make build-docker`
 
 It will take the local version of the code (with your changes in, if any) and use it.
-To start the container, run `make docker-run`
+To start the container, run `make compose`
 
 In case you built the container and wants to access its shell for debugging, you can do so with `make docker-bash`
 

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -20,5 +20,7 @@ services:
       - redis
 networks:
   # The presence of these objects is sufficient to define them
-  backend: {}
+  backend:
+    external: true
+    name: ${BACKEND_NETWORK}
   redis: {}


### PR DESCRIPTION
Because FE and BE containers are in separate repos, we need an external "backend-network" to enable FE to talk to BE; updated the Makefile to create and remove this network on compose-up and compose-down. (see https://github.com/elvslv/frontend/pull/3)